### PR TITLE
[WIP] feature: Bring ReactiveUI.Fody

### DIFF
--- a/Egram.Components.Authorization/AuthorizationContext.cs
+++ b/Egram.Components.Authorization/AuthorizationContext.cs
@@ -1,126 +1,80 @@
 ﻿using System;
 using System.Reactive;
+using System.Reactive.Linq;
 using Avalonia.Threading;
-using Egram.Components.Authorization;
 using Egram.Components.Navigation;
 using Microsoft.Extensions.DependencyInjection;
+using ReactiveUI.Fody.Helpers;
 using ReactiveUI;
+using System.Threading.Tasks;
 
 namespace Egram.Components.Authorization
 {
     public class AuthorizationContext : ReactiveObject, IDisposable
     {
+        private readonly IDisposable _authorizationStateSubscription;
         private readonly Authorizer _authorizer;
         private readonly Navigator _navigator;
 
-        private readonly IDisposable _authorizationStateSubscription;
-        
-        public AuthorizationContext(
-            Authorizer authorizer,
-            Navigator navigator
-            )
-        {
-            _authorizer = authorizer;
-            _navigator = navigator;
+        public ReactiveCommand<Unit, Unit> RequestCodeCommand { get; }
+        public ReactiveCommand<Unit, Unit> SignupCommand { get; }
+        public ReactiveCommand<Unit, Unit> VerifyCodeCommand { get; }
+        public ReactiveCommand<Unit, Unit> CheckPasswordCommand { get; }
 
-            InitCommands();
-            
+        [Reactive] public string VerificationCode { get; set; }
+        [Reactive] public int ActiveFormIndex { get; set; }
+        [Reactive] public string PhoneNumber { get; set; }
+        [Reactive] public string FirstName { get; set; }
+        [Reactive] public string LastName { get; set; }
+        [Reactive] public string Password { get; set; }
+
+        public AuthorizationContext(Authorizer authorizer, Navigator navigator)
+        {
+            _authorizer = authorizer ?? throw new ArgumentNullException(nameof(authorizer));
+            _navigator = navigator ?? throw new ArgumentNullException(nameof(navigator));
+
+            var canRequestCode = this
+                .WhenAnyValue(x => x.PhoneNumber)
+                .Select(x => !string.IsNullOrWhiteSpace(x));
+
+            RequestCodeCommand = ReactiveCommand.CreateFromTask(
+                () => _authorizer.SetPhoneNumber(PhoneNumber), 
+                canRequestCode, AvaloniaScheduler.Instance);
+
+            SignupCommand = ReactiveCommand.Create(
+                () => { ActiveFormIndex = 2; },
+                null, AvaloniaScheduler.Instance);
+
+            var canVerifyCode = this
+                .WhenAnyValue(x => x.VerificationCode)
+                .Select(x => !string.IsNullOrWhiteSpace(x));
+
+            VerifyCodeCommand = ReactiveCommand.CreateFromTask(
+                VerifyCode, canVerifyCode, AvaloniaScheduler.Instance);
+
+            var canCheckPassword = this
+                .WhenAnyValue(x => x.Password)
+                .Select(x => !string.IsNullOrWhiteSpace(x));
+
+            CheckPasswordCommand = ReactiveCommand.CreateFromTask(
+                () => authorizer.CheckPassword(Password),
+                canCheckPassword, AvaloniaScheduler.Instance);
+
             _authorizationStateSubscription = _authorizer
                 .States()
                 .Subscribe(ObserveAuthorizationState);
         }
-        
-        private int _activeFormIndex;
-        public int ActiveFormIndex
-        {
-            get => _activeFormIndex;
-            set => this.RaiseAndSetIfChanged(ref _activeFormIndex, value);
-        }
 
-        private string _phoneNumber;
-        public string PhoneNumber
+        private Task VerifyCode()
         {
-            get => _phoneNumber;
-            set => this.RaiseAndSetIfChanged(ref _phoneNumber, value);
-        }
-
-        private string _firstName;
-        public string FirstName
-        {
-            get => _firstName;
-            set => this.RaiseAndSetIfChanged(ref _firstName, value);
-        }
-
-        private string _lastName;
-        public string LastName
-        {
-            get => _lastName;
-            set => this.RaiseAndSetIfChanged(ref _lastName, value);
-        }
-
-        private string _verificationCode;
-        public string VerificationCode
-        {
-            get => _verificationCode;
-            set => this.RaiseAndSetIfChanged(ref _verificationCode, value);
-        }
-
-        private string _password;
-        public string Password
-        {
-            get => _password;
-            set => this.RaiseAndSetIfChanged(ref _password, value);
-        }
-        
-        public ReactiveCommand<Unit, Unit> RequestCodeCommand { get; private set; }
-            
-        public ReactiveCommand<Unit, Unit> SignupCommand { get; private set; }
-            
-        public ReactiveCommand<Unit, Unit> VerifyCodeCommand { get; private set; }
-
-        public ReactiveCommand<Unit, Unit> CheckPasswordCommand { get; private set; }
-
-        private void InitCommands()
-        {
-            // Phone number form
-            RequestCodeCommand = ReactiveCommand.CreateFromTask(async () =>
-                {
-                    await _authorizer.SetPhoneNumber(_phoneNumber);
-                },
-                null,
-                AvaloniaScheduler.Instance);
-            
-            // Signup form
-            SignupCommand = ReactiveCommand.Create(() => {},
-                null,
-                AvaloniaScheduler.Instance);
-            SignupCommand.Subscribe(_ =>
+            if (string.IsNullOrEmpty(FirstName))
             {
-                ActiveFormIndex = 2;
-            });
-            
-            // Verify code form
-            VerifyCodeCommand = ReactiveCommand.CreateFromTask(async () =>
-                {
-                    if (string.IsNullOrEmpty(_firstName))
-                    {
-                        await _authorizer.CheckCode(_verificationCode);
-                    }
-                    else
-                    {
-                        await _authorizer.CheckCode(_verificationCode, _firstName, _lastName);
-                    }
-                },
-                null,
-                AvaloniaScheduler.Instance);
-            
-            // Password form
-            CheckPasswordCommand = ReactiveCommand.CreateFromTask(async () =>
-                {
-                    await _authorizer.CheckPassword(_password);
-                },
-                null,
-                AvaloniaScheduler.Instance);
+                return _authorizer.CheckCode(VerificationCode);
+            }
+            else
+            {
+                return _authorizer.CheckCode(VerificationCode, FirstName, LastName);
+            }
         }
 
         private void ObserveAuthorizationState(TD.AuthorizationState state)

--- a/Egram.Components.Authorization/Egram.Components.Authorization.csproj
+++ b/Egram.Components.Authorization/Egram.Components.Authorization.csproj
@@ -7,7 +7,8 @@
     <PackageReference Include="Avalonia.Desktop" Version="0.6.1" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.6.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="ReactiveUI" Version="8.0.0-alpha0117" />
+    <PackageReference Include="ReactiveUI" Version="8.3.1" />
+    <PackageReference Include="ReactiveUI.Fody" Version="8.3.1" />
     <PackageReference Include="TDLib" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Egram.Components.Authorization/FodyWeavers.xml
+++ b/Egram.Components.Authorization/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Weavers>
+  <ReactiveUI />
+</Weavers>

--- a/Egram/Egram.csproj
+++ b/Egram/Egram.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-rc7" />
-    <PackageReference Include="ReactiveUI" Version="8.0.0-alpha0117" />
+    <PackageReference Include="ReactiveUI" Version="8.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Egram.Components.App\Egram.Components.App.csproj">

--- a/Egram/Registry/NavigationRegistry.cs
+++ b/Egram/Registry/NavigationRegistry.cs
@@ -1,5 +1,4 @@
 ﻿using Egram.Components.Navigation;
-using Egram.Components.Navigation;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Egram.Registry


### PR DESCRIPTION
ReactiveUI team has finished working on the `ReactiveUI.Fody` package so it is now <a href="https://www.nuget.org/packages/ReactiveUI.Fody/">available on NuGet</a>. `ReactiveUI.Fody` provides an efficient way of <a href="https://reactiveui.net/docs/handbook/view-models/#managing-boilerplate-code">managing boilderplate code</a>, instead of writing this:
```cs
public class ReactiveViewModel : ReactiveObject 
{
    private string password;
    public string Password
    {
        get => this.password;
        set => this.RaiseAndSetIfChanged(ref password, value);
    }
}
```
With `ReactiveUI.Fody` we would write this:
```cs
public class ReactiveViewModel : ReactiveObject 
{
    [Reactive] public string Password { get; set; }
}
```

So let's use ReactiveUI stable release and bring codegen to **Egram.Tel**! Why not? 
Let's discuss. 🥇 