### PR TITLE
[WIP] Attempt to use WhenActivated instead of bare metal IDisposables

### DIFF
--- a/application/Tel.Egram.Gui/Tel.Egram.Gui.csproj
+++ b/application/Tel.Egram.Gui/Tel.Egram.Gui.csproj
@@ -26,6 +26,7 @@
     <Folder Include="Icons\Dark" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\components\Tel.Egram.Components.Authentication\Tel.Egram.Components.Authentication.csproj" />
     <ProjectReference Include="..\..\services\Tel.Egram.Graphics\Tel.Egram.Graphics.csproj" />
     <ProjectReference Include="..\..\services\Tel.Egram.Messaging\Tel.Egram.Messaging.csproj" />
     <ProjectReference Include="..\..\services\Tel.Egram.Utils\Tel.Egram.Utils.csproj" />

--- a/application/Tel.Egram.Gui/Views/Authentication/AuthenticationControl.xaml.cs
+++ b/application/Tel.Egram.Gui/Views/Authentication/AuthenticationControl.xaml.cs
@@ -1,12 +1,15 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
 using Avalonia.Markup.Xaml;
+using Tel.Egram.Components.Authentication;
+using ReactiveUI;
 
 namespace Tel.Egram.Gui.Views.Authentication
 {
-    public class AuthenticationControl : UserControl
+    public class AuthenticationControl : ReactiveUserControl<AuthenticationController>
     {
         public AuthenticationControl()
         {
+            this.WhenActivated(disposables => { });
             AvaloniaXamlLoader.Load(this);
         }
     }

--- a/components/Tel.Egram.Components.Authentication/AuthenticationController.cs
+++ b/components/Tel.Egram.Components.Authentication/AuthenticationController.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using ReactiveUI;
 using TdLib;
@@ -9,67 +9,66 @@ using Tel.Egram.Utils;
 
 namespace Tel.Egram.Components.Authentication
 {
-    public class AuthenticationController : Controller<AuthenticationModel>
+    public class AuthenticationController : Controller<AuthenticationModel>, ISupportsActivation
     {
+        public ViewModelActivator Activator { get; }
+        
         public AuthenticationController(
             ISchedulers schedulers,
             IAuthenticator authenticator)
         {
-            BindAuthenticator(schedulers, authenticator)
-                .DisposeWith(this);
-        }
-
-        private IDisposable BindAuthenticator(
-            ISchedulers schedulers,
-            IAuthenticator authenticator)
-        {
-            var canSendCode = Model
-                .WhenAnyValue(x => x.PhoneNumber)
-                .Select(phone => !string.IsNullOrWhiteSpace(phone));
-            
-            var canCheckCode = Model
-                .WhenAnyValue(x => x.ConfirmCode)
-                .Select(code => !string.IsNullOrWhiteSpace(code));
-            
-            var canCheckPassword = Model
-                .WhenAnyValue(x => x.Password)
-                .Select(password => !string.IsNullOrWhiteSpace(password));
-            
-            Model.SendCodeCommand = ReactiveCommand.CreateFromObservable(
-                () => authenticator.SetPhoneNumber(Model.PhoneNumber),
-                canSendCode, schedulers.Main);
-
-            Model.CheckCodeCommand = ReactiveCommand.CreateFromObservable(
-                () => authenticator.CheckCode(Model.ConfirmCode, Model.FirstName, Model.LastName),
-                canCheckCode, schedulers.Main);
-            
-            Model.CheckPasswordCommand = ReactiveCommand.CreateFromObservable(
-                () => authenticator.CheckPassword(Model.Password),
-                canCheckPassword, schedulers.Main);
-            
-            var stateObservable = authenticator
-                .ObserveState()
-                .SubscribeOn(schedulers.Pool)
-                .ObserveOn(schedulers.Main);
-            
-            return stateObservable
-                .Subscribe(state =>
-                {
-                    switch (state)
+            Activator = new ViewModelActivator();
+            this.WhenActivated(disposables =>
+            {
+                var canSendCode = Model
+                    .WhenAnyValue(x => x.PhoneNumber)
+                    .Select(phone => !string.IsNullOrWhiteSpace(phone));
+                
+                var canCheckCode = Model
+                    .WhenAnyValue(x => x.ConfirmCode)
+                    .Select(code => !string.IsNullOrWhiteSpace(code));
+                
+                var canCheckPassword = Model
+                    .WhenAnyValue(x => x.Password)
+                    .Select(password => !string.IsNullOrWhiteSpace(password));
+                
+                Model.SendCodeCommand = ReactiveCommand.CreateFromObservable(
+                    () => authenticator.SetPhoneNumber(Model.PhoneNumber),
+                    canSendCode, schedulers.Main);
+    
+                Model.CheckCodeCommand = ReactiveCommand.CreateFromObservable(
+                    () => authenticator.CheckCode(Model.ConfirmCode, Model.FirstName, Model.LastName),
+                    canCheckCode, schedulers.Main);
+                
+                Model.CheckPasswordCommand = ReactiveCommand.CreateFromObservable(
+                    () => authenticator.CheckPassword(Model.Password),
+                    canCheckPassword, schedulers.Main);
+                
+                var stateObservable = authenticator
+                    .ObserveState()
+                    .SubscribeOn(schedulers.Pool)
+                    .ObserveOn(schedulers.Main);
+                
+                stateObservable
+                    .Subscribe(state =>
                     {
-                        case TdApi.AuthorizationState.AuthorizationStateWaitPhoneNumber _:
-                            OnWaitingPhoneNumber();
-                            break;
-                        
-                        case TdApi.AuthorizationState.AuthorizationStateWaitCode wait:
-                            OnWaitingConfirmCode(!wait.IsRegistered);
-                            break;
-                        
-                        case TdApi.AuthorizationState.AuthorizationStateWaitPassword _:
-                            OnWaitingPassword();
-                            break;
-                    }
-                });
+                        switch (state)
+                        {
+                            case TdApi.AuthorizationState.AuthorizationStateWaitPhoneNumber _:
+                                OnWaitingPhoneNumber();
+                                break;
+                            
+                            case TdApi.AuthorizationState.AuthorizationStateWaitCode wait:
+                                OnWaitingConfirmCode(!wait.IsRegistered);
+                                break;
+                            
+                            case TdApi.AuthorizationState.AuthorizationStateWaitPassword _:
+                                OnWaitingPassword();
+                                break;
+                        }
+                    })
+                    .DisposeWith(disposables);
+            });
         }
         
         private void OnWaitingPhoneNumber()


### PR DESCRIPTION
ReactiveUI provides a *better* way for managing ViewModel activation and deactivation — [WhenActivated](https://reactiveui.net/docs/handbook/when-activated/). We should try to stop managing disposables by hand and making our code base so complex, it's better to let the framework manage memory for us.